### PR TITLE
Build nipkg as part of build pipeline

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -57,3 +57,8 @@ type = 'lvBuildSpecAllTargets'
 project = '{linux32}'
 build_spec = 'Linux 32 - release'
 dependency_target = 'linux32'
+
+[package]
+type = 'nipkg'
+payload_dir = 'Built'
+install_destination = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices'

--- a/control
+++ b/control
@@ -1,15 +1,14 @@
-Package: scan-engine-and-ethercat-custom-device-{version}
-Version: 4.4.1
+Package: ni-scan-engine-veristand-{veristand_version}-support
+Version: {nipkg_version}
 Architecture: windows_x64
 Maintainer: National Instruments <support@ni.com>
 XB-Plugin: file
-Description:  This package allows users to easily read scanned I/O from C series modules located in a CompactRIO or NI 9144 EtherCAT chassis. The add-on also supports custom FPGA personalities to be used with a 914x chassis and support for both Remote I/O and generic EtherCAT slaves (PDO only).
-XB-Eula:  
+Description: Provides support for the NI Scan Engine and EtherCAT custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
 Priority: standard
 Homepage: http://www.ni.com
 XB-LanguageSupport: en
 XB-UserVisible: yes
 Section: Add-Ons
-XB-DisplayVersion: 4.4.1
-XB-DisplayName: Scan Engine and EtherCAT Custom Device for VeriStand {version}
-Depends: 
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI Scan Engine and EtherCAT for VeriStand {veristand_version}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows nipkg to be built as part of the Scan Engine custom device pipeline for release branches.

### Why should this Pull Request be merged?

Testing the actual installers we produce and ship is vital. By building the nipkg installer as part of the build process, our automated test system can validate the exact binaries and installers customers will use.

### What testing has been done?

- Verified installer version matches version of release branch and that installer executes and places correct binaries in the correct location
- Successfully added Scan Engine and EtherCAT custom device to VeriStand 2018 after installation
