### PR TITLE
Enable builds for 2017, 2018, post builds to more permanent location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,9 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-def lvVersions = ['2018']
+def lvVersions = ['2017', '2018']
 
 List<String> dependencies = ['niveristand-scan-engine-fxp-libraries', 'niveristand-scan-engine-module-libraries']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions, dependencies)
-diffPipeline('2018')
+diffPipeline('2017')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,4 +7,4 @@ def lvVersions = ['2017', '2018']
 List<String> dependencies = ['niveristand-scan-engine-fxp-libraries', 'niveristand-scan-engine-module-libraries']
 
 ni.vsbuild.PipelineExecutor.execute(this, 'veristand', lvVersions, dependencies)
-diffPipeline('2017')
+diffPipeline(lvVersions[0])

--- a/build.toml
+++ b/build.toml
@@ -1,6 +1,6 @@
 [archive]
 build_output_dir = 'Built'
-archive_location = '\\nirvana\temp\vs_cds\scan_engine_custom_device'
+archive_location = '\\nirvana\Measurements\VeriStandAddons\scan_engine_custom_device'
 
 [dependencies.niveristand-scan-engine-fxp-libraries]
 libraries = ['FXP.llb']


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Enable builds for 2015-2018, post builds to more permanent location

### Why should this Pull Request be merged?
Right now we only build for 2018, and our builds are ephemeral.

### What testing has been done?
This pull request will be built.