### PR TITLE
Revert README.md because custom device version was not bumped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scan Engine Custom Device
 
-**Scan Engine Custom Device**  allows users to easily read scanned I/O from C series modules located in a CompactRIO or NI 914x EtherCAT chassis. The add-on also supports custom FPGA personalities to be used with a 914x chassis. From version 4.4.1, there is support for NI Remote I/O modules as well. Version 4.4.2 fixes Issue #12. It introduces a Conditional Disable Symbol called: "LV_Version". It must be set to right version (2016, 2017, 2018) before compilation. 
+**Scan Engine Custom Device**  allows users to easily read scanned I/O from C series modules located in a CompactRIO or NI 914x EtherCAT chassis. The add-on also supports custom FPGA personalities to be used with a 914x chassis. From version 4.3, there is support for generic EtherCAT slaves (PDO only). From version 4.4.1, there is support for NI Remote I/O modules as well.
 
 ## LabVIEW Version
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Reverts README to previous version because referenced changes were not added in that pull request.

### Why should this Pull Request be merged?

README is incorrect.

### What testing has been done?

None
