### PR TITLE
Update LabVIEW and driver dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## LabVIEW Version
 
-LabVIEW 2016
+LabVIEW 2017
 
 ## Dependencies
 
 - The packed library build from [Scan Engine Custom Device Module Libraries](https://github.com/ni/niveristand-scan-engine-module-libraries).
 - The FXP build from [Scan Engine Custom Device FXP Libraries](https://github.com/ni/niveristand-scan-engine-fxp-libraries).
-- NI Industrial Communications for EtherCAT 16.1+
+- NI Industrial Communications for EtherCAT 17.6+
 - NI RIO
 
 ## Git History & Rebasing Policy


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update minimum LabVIEW version to 2017, NI Industrial Communications for EtherCAT version to 17.6.

### Why should this Pull Request be merged?

These should have been updated when the repository was mass-compiled to 2017 as part of https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/commit/398fa2f2b95a0358733b74643e9bad4b6a480dae.

### What testing has been done?

None