### PR TITLE
Set test system hostnames to match the test farm

### DIFF
--- a/Custom Device Source/Tests/EtherCAT System Tests/Assets/config.ini
+++ b/Custom Device Source/Tests/EtherCAT System Tests/Assets/config.ini
@@ -1,2 +1,2 @@
 [Overrides]
-"Targets/Controller/IP Address" = "10.2.64.29"
+"Targets/Controller/IP Address" = "VS-Eco-Slave-8880"

--- a/Custom Device Source/Tests/Specialty Digital System Tests/Assets/config.ini
+++ b/Custom Device Source/Tests/Specialty Digital System Tests/Assets/config.ini
@@ -1,2 +1,2 @@
 [Overrides]
-"Targets/Controller/IP Address" = "10.2.64.28"
+"Targets/Controller/IP Address" = "VS-Eco-FA-9045"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Set the default hostname/ip addresses for the tests to point to the test farm.


### Why should this Pull Request be merged?

We currently are not configuring the hostnames during the test execution, and use the default values.

### What testing has been done?

Booted the PXI chassis into PharLap and ran the tests from my PC (pointed at the hosts in the test farm).

Note that the remote IO test is failing due to the hardware not being present.
![image](https://user-images.githubusercontent.com/573497/58500746-62662300-8148-11e9-869c-ea1a46ec749e.png)
