### PR TITLE
Escape paths in toml keys

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -58,5 +58,5 @@ type = 'nipkg'
 package_output_dir = 'Built'
 
 [package.payload_map]
-'Built\Scan Engine' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Scan Engine'
-'Built\Errors' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Built\\Scan Engine' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Scan Engine'
+'Built\\Errors' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Escapes backslash characters in the build.toml keys for package payloads.

### Why should this Pull Request be merged?

The latest toml package from python does not like unescaped backslash characters in keys, so the custom device build is broken.

### What testing has been done?

[Built](http://coordinator/job/VeriStand/job/ni/job/niveristand-scan-engine-ethercat-custom-device/job/dev%252Ftoml_error/1/)
