### PR TITLE
Install to bitness-specific locations

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -53,7 +53,7 @@ package_output_dir = 'Built'
 
 [package.payload_map]
 'Built\\Scan Engine' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Scan Engine'
-'Built\\Errors' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Built\\Errors' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{veristand_version}\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -61,7 +61,7 @@ control_file = 'control_scripting'
 package_output_dir = 'Built'
 
 [package.payload_map]
-'Built\\Scripting\\Scan Engine' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Scan Engine' 
+'Built\\Scripting\\Scan Engine' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\Scan Engine'
 
 [[package]]
 type = 'nipkg'
@@ -69,7 +69,7 @@ control_file = 'control_examples'
 package_output_dir = 'Built'
 
 [package.payload_map]
-'Built\\Examples\\Scan Engine' = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\Scan Engine' 
+'Built\\Examples\\Scan Engine' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\Scan Engine'
 
 [notification]
 type = 'teams'

--- a/control
+++ b/control
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Scan Engine and EtherCAT for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_examples
+++ b/control_examples
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Scan Engine and EtherCAT LabVIEW Examples for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-scan-engine-veristand-{veristand_version}-labview-support (>= {display_version})
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-scan-engine-veristand-{veristand_version}-labview-support (>= {display_version})

--- a/control_scripting
+++ b/control_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Scan Engine and EtherCAT LabVIEW Support for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix}, ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update package installation paths and dependencies to accommodate different LabVIEW bitnesses.

### Why should this Pull Request be merged?

We are using LabVIEW 2021 64-bit.

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
