### PR TITLE
Build combined package for 2021 32- and 64-bit builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,5 @@ def lvVersions = [
 
 List<String> dependencies = ['niveristand-scan-engine-fxp-libraries', 'niveristand-scan-engine-module-libraries']
 
-env.'niveristand-scan-engine-fxp-libraries_DEP_DIR' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_fxp\\ni\\export\\main\\Build 314'
-env.'niveristand-scan-engine-module-libraries_DEP_DIR' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_modules\\ni\\export\\main\\Build 313'
-
 diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,8 @@ def lvVersions = [
 
 List<String> dependencies = ['niveristand-scan-engine-fxp-libraries', 'niveristand-scan-engine-module-libraries']
 
-env.'niveristand-scan-engine-fxp-libraries' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_fxp\\ni\\export\\main\\Build 314'
-env.'niveristand-scan-engine-module-libraries' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_modules\\ni\\export\\main\\Build 313'
+env.'niveristand-scan-engine-fxp-libraries_DEP_DIR' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_fxp\\ni\\export\\main\\Build 314'
+env.'niveristand-scan-engine-module-libraries_DEP_DIR' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_modules\\ni\\export\\main\\Build 313'
 
 diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,5 +9,8 @@ def lvVersions = [
 
 List<String> dependencies = ['niveristand-scan-engine-fxp-libraries', 'niveristand-scan-engine-module-libraries']
 
+env.'niveristand-scan-engine-fxp-libraries' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_fxp\\ni\\export\\main\\Build 314'
+env.'niveristand-scan-engine-module-libraries' = '\\\\nirvana\\Measurements\\VeriStandAddons\\scan_engine_modules\\ni\\export\\main\\Build 313'
+
 diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions, dependencies)

--- a/build.toml
+++ b/build.toml
@@ -113,6 +113,8 @@ vi = 'Custom Device Source\Build VIs\Delete Scripting API.vi'
 [[package]]
 type = 'nipkg'
 package_output_dir = 'Built'
+multi_bitness = 'true'
+multi_bitness_versions = ['2021']
 
 [package.payload_map]
 'Built\\Scan Engine' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Scan Engine'

--- a/build.toml
+++ b/build.toml
@@ -124,6 +124,8 @@ multi_bitness_versions = ['2021']
 type = 'nipkg'
 control_file = 'control_scripting'
 package_output_dir = 'Built'
+multi_bitness = 'true'
+multi_bitness_versions = ['2021']
 
 [package.payload_map]
 'Built\\Scripting\\Scan Engine' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\Scan Engine'
@@ -132,6 +134,8 @@ package_output_dir = 'Built'
 type = 'nipkg'
 control_file = 'control_examples'
 package_output_dir = 'Built'
+multi_bitness = 'true'
+multi_bitness_versions = ['2021']
 
 [package.payload_map]
 'Built\\Examples\\Scan Engine' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\Scan Engine'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Combines the output of the LabVIEW 2021 32- and 64-bit builds into a single `.nipkg` file.

### Why should this Pull Request be merged?

This is needed to install everything required for 2021 with a single package as is done for 2019 and 2020.

### What testing has been done?

PR build and inspected output of all packages. This change needs [Build Tools 124](https://github.com/ni/niveristand-custom-device-build-tools/pull/124) to be merged before it will produce results.
