### PR TITLE
Add azure pipeline and custom packaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,10 +32,10 @@ stages:
           bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
-        - version: '2023'
-          bitness: '32bit'
-        - version: '2023'
-          bitness: '64bit'
+        # - version: '2023'
+        #   bitness: '32bit'
+        # - version: '2023'
+        #   bitness: '64bit'
 
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
@@ -153,6 +153,10 @@ stages:
   - stage: CustomPackaging
     displayName: Package
     dependsOn: Build
+    pool:
+      name: custom-device-temp # TEMPORARY, eventually use an official build pool of custom device agents!!
+      demands:
+        - agent.os -equals Windows_NT
     jobs:
       - job: CustomPackageJob
         displayName: Custom Package
@@ -166,7 +170,7 @@ stages:
               lvVersions:
                 - '2020'
                 - '2021'
-                - '2023'
+                # - '2023'
               packages:
                 - controlFileName: 'control'
                   payloadMaps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,21 +150,36 @@ stages:
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_custom_device'
 
-# Test Building multiple packages with multiple payload maps
-      packages:
-        - controlFileName: 'control'
-          payloadMaps:
-            - payloadLocation: 'Built\Scan Engine'
-              installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Scan Engine'
-            - payloadLocation: 'Built\Errors'
-              installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\LabVIEW Run-Time\$(lvVersion)\errors\English'
+  - stage: Custom Package
+    displayName: Package
+    jobs:
+      - job: CustomPackageJob
+        displayName: Custom Package
+        steps:
+          - template: custom-packaging.yml
+            parameters:
+        # Parameters from above.  Scan Engine requires a custom package building stage after all items have been archived.  this custom packaging stage is derived from the template jobs in build-tools
+              releaseVersion: '23.0.0'
+              quarterlyReleaseVersion: '2023 Q1'
+              archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_custom_device'
+              lvVersions:
+                - '2020'
+                - '2021'
+                - '2023'
+              packages:
+                - controlFileName: 'control'
+                  payloadMaps:
+                    - payloadLocation: 'Scan Engine'
+                      installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Scan Engine'
+                    - payloadLocation: 'Errors'
+                      installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\LabVIEW Run-Time\$(lvVersion)\errors\English'
 
-        - controlFileName: 'control_scripting'
-          payloadMaps:
-            - payloadLocation: 'Built\Scripting\Scan Engine'
-              installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\Scan Engine'
+                - controlFileName: 'control_scripting'
+                  payloadMaps:
+                    - payloadLocation: 'Scripting\Scan Engine'
+                      installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\Scan Engine'
 
-        - controlFileName: 'control_examples'
-          payloadMaps:
-            - payloadLocation: 'Built\Examples\Scan Engine'
-              installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\Scan Engine'
+                - controlFileName: 'control_examples'
+                  payloadMaps:
+                    - payloadLocation: 'Examples\Scan Engine'
+                      installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\Scan Engine'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,170 @@
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+      - release/*
+
+resources:
+  repositories:
+    - repository: niveristand-custom-device-build-tools
+      type:       github
+      ref:        main
+      endpoint:   ni (2)
+      name:       ni/niveristand-custom-device-build-tools
+  pipelines:
+    - pipeline: FxpLibraries
+      source:   ni.niveristand-scan-engine-fxp-libraries
+      trigger:  true
+    - pipeline: ModuleLibraries
+      source:   ni.niveristand-scan-engine-module-libraries
+      trigger:  true
+
+stages:
+  - template: azure-templates/stages.yml
+    parameters:
+
+# Test Versions - At least 1 of each supported LabVIEW version and 1 of each bitness
+      lvVersionsToBuild:
+        - version: '2020'
+          bitness: '32bit'
+        - version: '2021'
+          bitness: '32bit'
+        - version: '2021'
+          bitness: '64bit'
+        - version: '2023'
+          bitness: '32bit'
+        - version: '2023'
+          bitness: '64bit'
+
+# Test Dependencies - multiple dependencies that are expected in the build steps below this
+      dependencies:
+        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_fxp'
+          file: 'FXP.llb'
+          destination: 'Includes'
+        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_modules'
+          file: 'Modules.lvlibp'
+          destination: 'Includes'
+        - source: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_modules'
+          file: 'NI ECAT Remote IO.llb'
+          destination: 'Includes'
+
+# Test Codegen Steps
+      codegenVis:
+        - 'Custom Device Source\Build VIs\Delete Scripting API.vi'
+
+# Test Individual Build Specs using standard build operations in LabVIEW, and exclusion rules
+      buildSteps:
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Configuration Release'
+          exclusions:
+            - version: '2021'
+              bitness: '32bit'
+            - version: '2023'
+              bitness: '32bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Revert to Scan Mode'
+          exclusions:
+            - version: '2021'
+              bitness: '64bit'
+            - version: '2023'
+              bitness: '64bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Get HW Config'
+          exclusions:
+            - version: '2021'
+              bitness: '64bit'
+            - version: '2023'
+              bitness: '64bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Check and Download Bitfile'
+          exclusions:
+            - version: '2021'
+              bitness: '64bit'
+            - version: '2023'
+              bitness: '64bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Import ESI File'
+          exclusions:
+            - version: '2021'
+              bitness: '64bit'
+            - version: '2023'
+              bitness: '64bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Read Target ESI Files'
+          exclusions:
+            - version: '2021'
+              bitness: '64bit'
+            - version: '2023'
+              bitness: '64bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine Linux x64.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'Linux x64'
+          buildSpec: 'Engine Release'
+          exclusions:
+            - version: '2021'
+              bitness: '64bit'
+            - version: '2023'
+              bitness: '64bit'
+
+        - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Scripting API'
+          exclusions:
+            - version: '2021'
+              bitness: '32bit'
+            - version: '2023'
+              bitness: '32bit'
+
+        - projectLocation: 'Scripting Examples\Scan Engine Scripting Examples.lvproj'
+          buildOperation: 'ExecuteBuildSpec'
+          target: 'My Computer'
+          buildSpec: 'Examples'
+          exclusions:
+            - version: '2021'
+              bitness: '32bit'
+            - version: '2023'
+              bitness: '32bit'
+
+      releaseVersion: '23.0.0'
+      quarterlyReleaseVersion: '2023 Q1'
+      buildOutputLocation: 'Built'
+      archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_custom_device'
+
+# Test Building multiple packages with multiple payload maps
+      packages:
+        - controlFileName: 'control'
+          payloadMaps:
+            - payloadLocation: 'Built\Scan Engine'
+              installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Scan Engine'
+            - payloadLocation: 'Built\Errors'
+              installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\LabVIEW Run-Time\$(lvVersion)\errors\English'
+
+        - controlFileName: 'control_scripting'
+          payloadMaps:
+            - payloadLocation: 'Built\Scripting\Scan Engine'
+              installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\vi.lib\addons\VeriStand Custom Device Scripting APIs\Scan Engine'
+
+        - controlFileName: 'control_examples'
+          payloadMaps:
+            - payloadLocation: 'Built\Examples\Scan Engine'
+              installLocation: 'ni-paths-LV$(lvVersion)DIR$(nipkgx64suffix)\examples\NI VeriStand Custom Devices\Scan Engine'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,7 +163,7 @@ stages:
         steps:
           - template: custom-packaging.yml
             parameters:
-        # Parameters from above.  Scan Engine requires a custom package building stage after all items have been archived.  this custom packaging stage is derived from the template jobs in build-tools
+        # Scan Engine requires a custom package building stage after all items have been archived.  this custom packaging stage is derived from the template jobs in build-tools, so it uses the same parameters
               releaseVersion: '23.0.0'
               quarterlyReleaseVersion: '2023 Q1'
               archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_custom_device'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,10 +32,10 @@ stages:
           bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
-        # - version: '2023'
-        #   bitness: '32bit'
-        # - version: '2023'
-        #   bitness: '64bit'
+        - version: '2023'
+          bitness: '32bit'
+        - version: '2023'
+          bitness: '64bit'
 
 # Test Dependencies - multiple dependencies that are expected in the build steps below this
       dependencies:
@@ -170,7 +170,7 @@ stages:
               lvVersions:
                 - '2020'
                 - '2021'
-                # - '2023'
+                - '2023'
               packages:
                 - controlFileName: 'control'
                   payloadMaps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,7 +150,7 @@ stages:
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\prototype\scan_engine_custom_device'
 
-  - stage: Custom Package
+  - stage: CustomPackaging
     displayName: Package
     jobs:
       - job: CustomPackageJob

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,6 +152,7 @@ stages:
 
   - stage: CustomPackaging
     displayName: Package
+    dependsOn: Build
     jobs:
       - job: CustomPackageJob
         displayName: Custom Package

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -11,6 +11,9 @@ parameters:
     type: object
 
 steps:
+  - checkout: self
+    displayName: Check out repository to build
+
   - ${{ each lvVersion in parameters.lvVersions }}:
     - task: PowerShell@2
       displayName: Set up variables for custom packaging steps

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -1,0 +1,130 @@
+parameters:
+  - name: releaseVersion
+    type: string
+  - name: quarterlyReleaseVersion
+    type: string
+  - name: lvVersions
+    type: object
+  - name: archiveLocation
+    type: string
+  - name: packages
+    type: object
+
+steps:
+  - ${{ each lvVersion in parameters.lvVersions }}:
+    - task: PowerShell@2
+      displayName: Set up variables for custom packaging steps
+      inputs:
+        targetType: 'inline'
+        script: |
+          $customDeviceRepoName = '$(Build.Repository.Name)' -replace '.+\/', ''
+          Write-Host "##vso[task.setvariable variable=customDeviceRepoName]$customDeviceRepoName"
+          Write-Host "##vso[task.setvariable variable=nipkgPath]$customDeviceRepoName\nipkg"
+          Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}"" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}""...'
+          Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
+          Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]${{ parameters.quarterlyReleaseVersion }}'
+          Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'
+          If ('${{ parameters.lvVersionToBuild.version }}' -eq '2020')
+          {
+            Write-Host '##vso[task.setvariable variable=shortLvVersion]20'
+            Write-Host '##vso[task.setvariable variable=nipkgx64suffix]'
+          }
+          Elseif ('${{ parameters.lvVersionToBuild.version }}' -eq '2021')
+          {
+            Write-Host '##vso[task.setvariable variable=shortLvVersion]21'
+            Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
+          }
+          Elseif ('${{ parameters.lvVersionToBuild.version }}' -eq '2023')
+          {
+            Write-Host '##vso[task.setvariable variable=shortLvVersion]23'
+            Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
+          }
+          Else
+          {
+            Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, or 2023."
+          }
+          If ('$(Build.Reason)' -eq 'PullRequest')
+          {
+            $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
+          }
+          Else
+          {
+            $sourceBranch = "$(Build.SourceBranchName)"
+          }
+          Write-Host "##vso[task.setvariable variable=archivePath]${{ parameters.archiveLocation }}\NI\export\$sourceBranch\"
+
+    - ${{ each package in parameters.packages }}:
+      - ${{ if ne(package.controlFileName, '') }}:
+        - task: PowerShell@2
+          displayName: Stage nipkg directory
+          inputs:
+            targetType: 'inline'
+            script: |
+              Write-Output "setting up nipkg directory..."
+              If (Test-Path '$(nipkgPath)')
+              {
+                Remove-Item -Path '$(nipkgPath)' -Recurse -Force
+              }
+              New-Item -Path '$(nipkgPath)' -ItemType 'Directory'
+              New-Item -Path '$(nipkgPath)' -Name 'control' -ItemType 'Directory'
+              New-Item -Path '$(nipkgPath)' -Name 'data' -ItemType 'Directory'
+              New-Item -Path '$(nipkgPath)' -Name 'debian-binary' -ItemType 'File'
+              Set-Content '$(nipkgPath)\debian-binary' '2.0\n'
+              Copy-Item `
+                -Path '$(customDeviceRepoName)\${{ package.controlFileName }}' `
+                -Destination '$(nipkgPath)\control\control'
+              `
+              Write-Output "updating nipkg control version parameters..."
+              $contents = (Get-Content -Path '$(nipkgPath)\control\control')`
+                -replace '{veristand_version}', '$(lvVersion)'`
+                -replace '{labview_version}', '$(lvVersion)'`
+                -replace '{nipkg_version}', '$(releaseVersion)'`
+                -replace '{display_version}', '$(releaseVersion)'`
+                -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
+                -replace '{labview_short_version}', '$(shortLvVersion)'
+              Write-Output $contents
+              Set-Content -Value $contents -Path '$(nipkgPath)\control\control'
+
+        - ${{ each payloadMap in package.payloadMaps }}:
+          - task: PowerShell@2
+            displayName: Copying payload ${{ payloadMap.payloadLocation }} to install location
+            inputs:
+              targetType: 'inline'
+              script: |
+                New-Item -Path '$(nipkgPath)\data\${{ payloadMap.installLocation }}' -ItemType 'Directory'
+                If (Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}")
+                {
+                  $payloadArchiveLocation = "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}"
+                }
+                Elseif (Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}")
+                {
+                  $payloadArchiveLocation = "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}"
+                }
+                Else
+                {
+                  Write-Error "Archived payload is not found for either bitness"
+                }
+                Copy-Item `
+                  -Path '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}\*' `
+                  -Destination '$(nipkgPath)\data\${{ payloadMap.installLocation }}'
+
+        - task: CmdLine@2
+          displayName: Pack nipkg
+          inputs:
+            script: '"%PROGRAMFILES%\National Instruments\NI Package Manager\nipkg.exe" pack "$(nipkgPath)" "$(nipkgPath)"'
+
+        - task: PowerShell@2
+          displayName: Copy installer to build output location
+          inputs:
+            targetType: 'inline'
+            script: |
+              $installerPath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer'
+              If (-not(Test-Path $installerPath))
+              {
+                New-Item -Path $installerPath -ItemType 'Directory'
+              }
+              Copy-Item `
+                -Path '$(nipkgPath)\*' `
+                -Destination $installerPath `
+                -Include *.nipkg `
+                -Recurse

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -23,25 +23,25 @@ steps:
           Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}"...'
           Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
           Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]${{ parameters.quarterlyReleaseVersion }}'
-          Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'
-          If ('${{ parameters.lvVersionToBuild.version }}' -eq '2020')
+          Write-Host '##vso[task.setvariable variable=lvVersion]${{ lvVersion }}'
+          If ('${{ lvVersion }}' -eq '2020')
           {
             Write-Host '##vso[task.setvariable variable=shortLvVersion]20'
             Write-Host '##vso[task.setvariable variable=nipkgx64suffix]'
           }
-          Elseif ('${{ parameters.lvVersionToBuild.version }}' -eq '2021')
+          Elseif ('${{ lvVersion }}' -eq '2021')
           {
             Write-Host '##vso[task.setvariable variable=shortLvVersion]21'
             Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
           }
-          Elseif ('${{ parameters.lvVersionToBuild.version }}' -eq '2023')
+          Elseif ('${{ lvVersion }}' -eq '2023')
           {
             Write-Host '##vso[task.setvariable variable=shortLvVersion]23'
             Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
           }
           Else
           {
-            Write-Error "Invalid LabVIEW version defined in pipeline.  Use either 2020, 2021, or 2023."
+            Write-Error "Invalid LabVIEW version defined in pipeline: ${{ lvVersion }}.  Use either 2020, 2021, or 2023."
           }
           If ('$(Build.Reason)' -eq 'PullRequest')
           {

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -20,7 +20,7 @@ steps:
           $customDeviceRepoName = '$(Build.Repository.Name)' -replace '.+\/', ''
           Write-Host "##vso[task.setvariable variable=customDeviceRepoName]$customDeviceRepoName"
           Write-Host "##vso[task.setvariable variable=nipkgPath]$customDeviceRepoName\nipkg"
-          Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}"" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}""...'
+          Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}"...'
           Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
           Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]${{ parameters.quarterlyReleaseVersion }}'
           Write-Host '##vso[task.setvariable variable=lvVersion]${{ parameters.lvVersionToBuild.version }}'

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -20,9 +20,6 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
-          $customDeviceRepoName = '$(Build.Repository.Name)' -replace '.+\/', ''
-          Write-Host "##vso[task.setvariable variable=customDeviceRepoName]$customDeviceRepoName"
-          Write-Host "##vso[task.setvariable variable=nipkgPath]$customDeviceRepoName\nipkg"
           Write-Output 'Configuring release version to "${{ parameters.releaseVersion }}" and quarterlyReleaseVersion to "${{ parameters.quarterlyReleaseVersion }}"...'
           Write-Host '##vso[task.setvariable variable=releaseVersion]${{ parameters.releaseVersion }}'
           Write-Host '##vso[task.setvariable variable=quarterlyReleaseVersion]${{ parameters.quarterlyReleaseVersion }}'
@@ -64,21 +61,21 @@ steps:
             targetType: 'inline'
             script: |
               Write-Output "setting up nipkg directory..."
-              If (Test-Path '$(nipkgPath)')
+              If (Test-Path 'nipkg')
               {
-                Remove-Item -Path '$(nipkgPath)' -Recurse -Force
+                Remove-Item -Path 'nipkg' -Recurse -Force
               }
-              New-Item -Path '$(nipkgPath)' -ItemType 'Directory'
-              New-Item -Path '$(nipkgPath)' -Name 'control' -ItemType 'Directory'
-              New-Item -Path '$(nipkgPath)' -Name 'data' -ItemType 'Directory'
-              New-Item -Path '$(nipkgPath)' -Name 'debian-binary' -ItemType 'File'
-              Set-Content '$(nipkgPath)\debian-binary' '2.0\n'
+              New-Item -Path 'nipkg' -ItemType 'Directory'
+              New-Item -Path 'nipkg' -Name 'control' -ItemType 'Directory'
+              New-Item -Path 'nipkg' -Name 'data' -ItemType 'Directory'
+              New-Item -Path 'nipkg' -Name 'debian-binary' -ItemType 'File'
+              Set-Content 'nipkg\debian-binary' '2.0\n'
               Copy-Item `
-                -Path '$(customDeviceRepoName)\${{ package.controlFileName }}' `
-                -Destination '$(nipkgPath)\control\control'
+                -Path '${{ package.controlFileName }}' `
+                -Destination 'nipkg\control\control'
               `
               Write-Output "updating nipkg control version parameters..."
-              $contents = (Get-Content -Path '$(nipkgPath)\control\control')`
+              $contents = (Get-Content -Path 'nipkg\control\control')`
                 -replace '{veristand_version}', '$(lvVersion)'`
                 -replace '{labview_version}', '$(lvVersion)'`
                 -replace '{nipkg_version}', '$(releaseVersion)'`
@@ -86,7 +83,7 @@ steps:
                 -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
                 -replace '{labview_short_version}', '$(shortLvVersion)'
               Write-Output $contents
-              Set-Content -Value $contents -Path '$(nipkgPath)\control\control'
+              Set-Content -Value $contents -Path 'nipkg\control\control'
 
         - ${{ each payloadMap in package.payloadMaps }}:
           - task: PowerShell@2
@@ -94,7 +91,7 @@ steps:
             inputs:
               targetType: 'inline'
               script: |
-                New-Item -Path '$(nipkgPath)\data\${{ payloadMap.installLocation }}' -ItemType 'Directory'
+                New-Item -Path 'nipkg\data\${{ payloadMap.installLocation }}' -ItemType 'Directory'
                 If (Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}")
                 {
                   $payloadArchiveLocation = "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}"
@@ -109,12 +106,12 @@ steps:
                 }
                 Copy-Item `
                   -Path '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}\*' `
-                  -Destination '$(nipkgPath)\data\${{ payloadMap.installLocation }}'
+                  -Destination 'nipkg\data\${{ payloadMap.installLocation }}'
 
         - task: CmdLine@2
           displayName: Pack nipkg
           inputs:
-            script: '"%PROGRAMFILES%\National Instruments\NI Package Manager\nipkg.exe" pack "$(nipkgPath)" "$(nipkgPath)"'
+            script: '"%PROGRAMFILES%\National Instruments\NI Package Manager\nipkg.exe" pack "nipkg" "nipkg"'
 
         - task: PowerShell@2
           displayName: Copy installer to build output location
@@ -127,7 +124,7 @@ steps:
                 New-Item -Path $installerPath -ItemType 'Directory'
               }
               Copy-Item `
-                -Path '$(nipkgPath)\*' `
+                -Path 'nipkg\*' `
                 -Destination $installerPath `
                 -Include *.nipkg `
                 -Recurse


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds an Azure pipeline to the SEECD, which requires a custom packaging section and all of the features of the azure pipelines build templates.  The custom packaging section copies some of the features in the normal pipeline, but since SEECD needs to package after multiple builds have finished to use x86 and x64 outputs in the packaging, the package is done in a second stage after all jobs are complete, with a custom yaml template for that stage.

### Why should this Pull Request be merged?

SEECD is a unique and the most complex pipeline for custom devices so it is necessary to make sure that it's working sooner than others.

### What testing has been done?

Check for builds to run.