### PR TITLE
add recurse to custom packaging

### DIFF
--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -107,6 +107,7 @@ steps:
                 Copy-Item `
                   -Path '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}\*' `
                   -Destination 'nipkg\data\${{ payloadMap.installLocation }}'
+                  -Recurse
 
         - task: CmdLine@2
           displayName: Pack nipkg


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Include changes made in this PR for the custom-packaging in Scan Engine custom device
https://github.com/ni/niveristand-custom-device-build-tools/pull/152

### Why should this Pull Request be merged?

If not recurse, only the parent directory will be copied when nipkg

### What testing has been done?

Will post nipkg output here when PR Build is complete.