### PR TITLE
Pack x86 and x64

### DIFF
--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -105,6 +105,10 @@ steps:
                   Write-Error "Archived payload is not found for either bitness"
                 }
                 Copy-Item `
+                  -Path '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}\*' `
+                  -Destination 'nipkg\data\${{ payloadMap.installLocation }}' `
+                  -Recurse
+                Copy-Item `
                   -Path '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}\*' `
                   -Destination 'nipkg\data\${{ payloadMap.installLocation }}' `
                   -Recurse


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Pack both x86 and x64 items with nipkg for each component, rather than just the x64 version, which is a bug in the current pipeline.

### Why should this Pull Request be merged?

2020 will be empty, and 2021-2023 will be missing components that are built in x86

### What testing has been done?

Checked the package on a pipeline build and all of the expected items are there.  Also, the sizes of the nipkg match jenkins builds.
![image](https://user-images.githubusercontent.com/42351034/223485273-2667b690-b878-44e4-9681-c6585f527e34.png)