### PR TITLE
Rename nipkg and remove unused powershell logic

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,6 +152,11 @@ stages:
       name: DevCentral-VeriStand-CustomDevices
       demands:
         - agent.os -equals Windows_NT
+    variables:
+      ${{ if ne(variables['Build.Reason'], 'PullRequest')}}:
+        buildCounter: $[counter("variables['Build.SourceBranch']custom", 1)]
+      ${{ if eq(variables['Build.Reason'], 'PullRequest')}}:
+        buildCounter: "9999"
     jobs:
       - job: CustomPackageJob
         displayName: Custom Package

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -154,7 +154,7 @@ stages:
         - agent.os -equals Windows_NT
     variables:
       ${{ if ne(variables['Build.Reason'], 'PullRequest')}}:
-        buildCounter: $[counter("variables['Build.SourceBranch']custom", 1)]
+        buildCounter: $[counter(format('custom {0}', variables['Build.SourceBranch']), 1)]
       ${{ if eq(variables['Build.Reason'], 'PullRequest')}}:
         buildCounter: "9999"
     jobs:

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -97,13 +97,13 @@ steps:
                 -Destination 'nipkg\control\control'
               `
               Write-Output "updating nipkg control version parameters..."
-              $contents = (Get-Content -Path 'nipkg\control\control')`
-                -replace '{veristand_version}', '$(lvVersion)'`
-                -replace '{labview_version}', '$(lvVersion)'`
-                -replace '{nipkg_version}', '$(releaseVersion)'`
-                -replace '{display_version}', '$(releaseVersion)'`
-                -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
-                -replace '{labview_short_version}', '$(shortLvVersion)' `
+              $contents = (Get-Content -Path "nipkg\control\control") `
+                -replace "{veristand_version}", "$(lvVersion)" `
+                -replace "{labview_version}", "$(lvVersion)" `
+                -replace "{nipkg_version}", "$(releaseVersion).$env:BUILDCOUNTER" `
+                -replace "{display_version}", "$(releaseVersion)" `
+                -replace "{quarterly_display_version}", "$(quarterlyReleaseVersion)" `
+                -replace "{labview_short_version}", "$(shortLvVersion)" `
                 -replace "{nipkgx64suffix}", "$(nipkgx64suffix)"
               Write-Output $contents
               Set-Content -Value $contents -Path 'nipkg\control\control'

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -73,14 +73,6 @@ steps:
           {
             Write-Error "Invalid LabVIEW version defined in pipeline: ${{ lvVersion }}.  Use either 2020, 2021, or 2023."
           }
-          If ('$(Build.Reason)' -eq 'PullRequest')
-          {
-            $sourceBranch = "$(System.PullRequest.SourceBranch)" -replace 'dev/', ''
-          }
-          Else
-          {
-            $sourceBranch = "$(Build.SourceBranchName)"
-          }
           Write-Host "##vso[task.setvariable variable=archivePath]${{ parameters.archiveLocation }}\NI\export\$sourceBranch\"
 
     - ${{ each package in parameters.packages }}:

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -18,6 +18,20 @@ steps:
       inputs:
         targetType: 'inline'
         script: |
+          If ('$(Build.Reason)' -eq 'PullRequest')
+          {
+            Write-Output "Setting variables for Pull Requests..."
+            $sourceBranch = "$(System.PullRequest.SourceBranch)"
+            Write-Output "Source branch $(System.PullRequest.SourceBranch)"
+          }
+          Else
+          {
+            Write-Output "Setting variables for general builds..."
+            $sourceBranch = "$(Build.SourceBranch)" -replace 'refs/heads/', ''
+            Write-Output "Source branch $(Build.SourceBranch), removed refs/heads/"
+          }
+          Write-Output "Using $sourceBranch in archive path..."
+          Write-Host "##vso[task.setvariable variable=sourceBranch]$sourceBranch"
           Write-Output 'Determining quarterlyReleaseVersion...'
           $releaseData = "${{ parameters.releaseVersion }}" -Split "\."
           If ($releaseData[1] -eq "0")

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -97,7 +97,8 @@ steps:
                 -replace '{nipkg_version}', '$(releaseVersion)'`
                 -replace '{display_version}', '$(releaseVersion)'`
                 -replace '{quarterly_display_version}', '$(quarterlyReleaseVersion)'`
-                -replace '{labview_short_version}', '$(shortLvVersion)'
+                -replace '{labview_short_version}', '$(shortLvVersion)' `
+                -replace "{nipkgx64suffix}", "$(nipkgx64suffix)"
               Write-Output $contents
               Set-Content -Value $contents -Path 'nipkg\control\control'
 
@@ -108,18 +109,6 @@ steps:
               targetType: 'inline'
               script: |
                 New-Item -Path 'nipkg\data\${{ payloadMap.installLocation }}' -ItemType 'Directory'
-                If (Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}")
-                {
-                  $payloadArchiveLocation = "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}"
-                }
-                Elseif (Test-Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}")
-                {
-                  $payloadArchiveLocation = "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x64\${{ payloadMap.payloadLocation }}"
-                }
-                Else
-                {
-                  Write-Error "Archived payload is not found for either bitness"
-                }
                 Copy-Item `
                   -Path '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\x86\${{ payloadMap.payloadLocation }}\*' `
                   -Destination 'nipkg\data\${{ payloadMap.installLocation }}' `
@@ -149,3 +138,23 @@ steps:
                 -Destination $installerPath `
                 -Include *.nipkg `
                 -Recurse
+
+  - task: PowerShell@2
+    displayName: Rename nipkg files to match branch type
+    inputs:
+      targetType: 'inline'
+      script: |
+        If (-not("$(sourceBranch)" -match "release"))
+        {
+          $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", "_"
+          Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg files..."
+          $packages = Get-ChildItem `
+            -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg"
+          Foreach ($package in $packages)
+          {
+            If (-not("$package" -match "$cleanedSourceBranch.nipkg"))
+            {
+              Rename-Item -Path "$package" -NewName ("$package" -replace ".nipkg", "_$cleanedSourceBranch.nipkg")
+            }
+          }
+        }

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -155,7 +155,7 @@ steps:
           $cleanedSourceBranch = "$(sourceBranch)" -replace "\/", "_"
           Write-Output "Not a release branch, so appending branch name $cleanedSourceBranch to nipkg files..."
           $packages = Get-ChildItem `
-            -Path "$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer\*.nipkg"
+            -Path "$(archivePath)\$(Build.BuildNumber)\*\installer\*.nipkg"
           Foreach ($package in $packages)
           {
             If (-not("$package" -match "$cleanedSourceBranch.nipkg"))


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This adds the renaming behavior that was implemented in https://github.com/ni/niveristand-custom-device-build-tools/pull/156 to the custom-packaging.yaml
It also removes some unused code that was sitting around and had the potential to throw errors.

### Why should this Pull Request be merged?

Renaming the nipkgs is needed to avoid confusion about which one is the released package now that we build them every time.
Additionally, the unused code might cause confusion in the future.

### What testing has been done?

Check the outputs of the PR build and a build I ran manually:

![image](https://user-images.githubusercontent.com/42351034/225114019-b8667486-9f13-484c-b596-01144ff2e951.png)
