### PR TITLE
Update Manual Build Instructions for 64-bit versions

### DIFF
--- a/docs/Files Needed for 64 bit Support.md
+++ b/docs/Files Needed for 64 bit Support.md
@@ -1,0 +1,65 @@
+## Files Needed to Build with LabVIEW 64-bit
+Because VeriStand 2021 and later only support LabVIEW 64-bit, several directories of VeriStand LabVIEW support files need duplicated to the LabVIEW 32-bit directory to build this custom device for those versions. This document details which directories to copy, as well as which driver support files need exposed to LabVIEW 64-bit.
+
+The file paths assume your install directory is on the C drive. Use the relative paths to `Program Files` and `Program Files (x86)` that match your Windows installation.
+
+### vi.lib
+VeriStand installs multiple APIs for LabVIEW, and these all need duplicated to LabVIEW 32-bit.
+
+#### vi.lib\NI
+These are VeriStand's native APIs, including the Custom Device API. Copy from 64-bit to 32-bit:
+
+```
+C:\Program Files\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI
+```
+
+to
+
+```
+C:\Program Files (x86)\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI
+```
+
+#### vi.lib\NI VeriStand
+This directory contains the addons from VeriStand's Custom Device Development Tools repository which are installed via NI Package. Copy from 64-bit to 32-bit:
+
+```
+C:\Program Files\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI VeriStand
+```
+
+to
+
+```
+C:\Program Files (x86)\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI VeriStand
+```
+
+### EtherCAT Driver Dependencies
+Because some EtherCAT driver calls are referenced from the Windows LabVIEW Project, the easiest way to avoid linking errors is to provide the necessary files for LabVIEW 64-bit.
+
+#### LabVIEW 2021 SP1
+For LabVIEW 2021 SP1 64-bit, this requires copying the following directory from 32-bit to 64-bit:
+
+```
+C:\Program Files (x86)\National Instruments\LabVIEW 2021\vi.lib\indcomecat\Remote IO
+```
+
+to
+
+```
+C:\Program Files\National Instruments\LabVIEW 2021\vi.lib\indcomecat\Remote IO
+```
+
+#### LabVIEW 2023 Q1
+For LabVIEW 2023 Q1 64-bit, this requires modifying the following file to enable 64-bit to access the driver's VIs:
+
+```
+C:\Program Files\NI\LVAddons\niecat\1\lvaddoninfo.json
+```
+
+Delete the last line, and remove the trailing comma of the preceeding line:
+
+```
+"SupportedBitness": "32"
+```
+
+### VI Package Dependencies
+VeriStand's Custom Device Development Tools repository [lists](https://github.com/ni/niveristand-custom-device-development-tools#vi-package-manager-hosted-on-the-labview-tools-network) several VI Package dependencies in its readme. These need to be installed for both LabVIEW 32-bit and 64-bit for the build to succeed.

--- a/docs/Files Needed for 64 bit Support.md
+++ b/docs/Files Needed for 64 bit Support.md
@@ -7,29 +7,29 @@ The file paths assume your install directory is on the C drive. Use the relative
 VeriStand installs multiple APIs for LabVIEW, and these all need duplicated to LabVIEW 32-bit.
 
 #### vi.lib\NI
-These are VeriStand's native APIs, including the Custom Device API. Copy from 64-bit to 32-bit:
+These are VeriStand's native APIs, including the Custom Device API. Copy from 64-bit to 32-bit for the required year-version of LabVIEW:
 
 ```
-C:\Program Files\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI
+C:\Program Files\National Instruments\LabVIEW 20XX\vi.lib\NI
 ```
 
 to
 
 ```
-C:\Program Files (x86)\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI
+C:\Program Files (x86)\National Instruments\LabVIEW 20XX\vi.lib\NI
 ```
 
 #### vi.lib\NI VeriStand
-This directory contains the addons from VeriStand's Custom Device Development Tools repository which are installed via NI Package. Copy from 64-bit to 32-bit:
+This directory contains the addons from VeriStand's Custom Device Development Tools repository which are installed via NI Package. Copy from 64-bit to 32-bit for the required year-version of LabVIEW:
 
 ```
-C:\Program Files\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI VeriStand
+C:\Program Files\National Instruments\LabVIEW 20XX\vi.lib\NI VeriStand
 ```
 
 to
 
 ```
-C:\Program Files (x86)\National Instruments\LabVIEW ${labview_x64_version}\vi.lib\NI VeriStand
+C:\Program Files (x86)\National Instruments\LabVIEW 20XX\vi.lib\NI VeriStand
 ```
 
 ### EtherCAT Driver Dependencies

--- a/docs/Manual Build Instructions.md
+++ b/docs/Manual Build Instructions.md
@@ -15,22 +15,34 @@ Glossary of Terms:
 - PPL = Packed Project Library designated by the file extension .lvlibp
 - LLB = LabVIEW Library that is a build artifact designated by the file extension .llb
 
+### LabVIEW 64-bit support for VeriStand 2021 and later
+Beginning with the 2021 release, VeriStand's LabVIEW-built components are built entirely using LabVIEW 64-bit. For most custom devices, this means LabVIEW 64-bit must be used to build all build specifications.
+
+However, this custom device uses two drivers that as of the 2023 Q1 releases lack LabVIEW 64-bit support: CompactRIO and EtherCAT. To work around this limitation, LabVIEW 32-bit is used to build:
+1. Applications to be called out-of-process that contain driver calls for Windows
+1. The RT engine LLB for LinuxRT targets
+
+See [Files Needed for 64 bit Support](Files%20Needed%20for%2064%20bit%20Support.md) for a list of modifications to allow this build to succeed. The instructions below will call out the LabVIEW bitness to use for each build step when building for VeriStand 2021 and later. If building for VeriStand 2020, ignore the bitness and use only LabVIEW 32-bit for all steps.
+
 ### 1. [Scan Engine FXP Libraries](https://github.com/ni/niveristand-scan-engine-fxp-libraries)
-1. Open `FXP LLB.lvproj`
+1. Open `FXP LLB.lvproj` in LabVIEW 32-bit
 1. Execute `Script FXP Write.vi`
 1. Execute `Script FXP Read.vi`
-1. Build the `FXP LLB` build specification for each target
+1. Build the `FXP LLB` build specification for the Linux x64 target
+1. Close LabVIEW 32-bit
 
 The final file structure of the `Built` directory should be as follows:
-- Windows
-    - FXP.llb
 - Linux_x64
     - FXP.llb
 
 ### 2. [Scan Engine Module Libraries](https://github.com/ni/niveristand-scan-engine-module-libraries)
-1. Open `Modules.lvproj`
-1. Build the `Modules` build specification for each target
-1. Build the `NI ECAT Remote IO` build specification for each target
+1. Open `Modules.lvproj` in LabVIEW 32-bit
+1. Build the `Modules` build specification for the Linux x64 target
+1. Build the `NI ECAT Remote IO` build specification for the Linux x64 target
+1. Close LabVIEW 32-bit
+1. Open `Modules.lvproj` in LabVIEW 64-bit
+1. Build the `Modules` build specification for the Windows target
+1. Build the `NI ECAT Remote IO` build specification for the Windows target
 
 The final file structure of the `Built` directory should be as follows:
 - Windows
@@ -45,22 +57,23 @@ The final file structure of the `Built` directory should be as follows:
     - FXP.llb
     - Modules.lvlibp
     - NI ECAT Remote IO.llb
-1. Open `Scan Engine.lvproj`
+1. Open `Scan Engine Linux x64.lvproj` in LabVIEW 32-bit
     - Depending on the versions of VeriStand and LabVIEW installed on the development PC, the version of the VeriStand .NET assemblies may mismatch with the project. Use .lvproj.config files to lock the version of the assemblies used by the project, or manually navigate to the assemblies on disk at `C:\Windows\Microsoft.NET\assembly\GAC_MSIL\`.
     - You may see dialogs concerning a mismatch of target versions when loading LLBs and PPLs for other operating systems. These are safe to ignore.
 1. Build the `Engine Release` build specification
-1. Close LabVIEW completely
+1. Close LabVIEW 32-bit completely
 1. Copy Windows dependencies from previous repositories' `Built` directory into the `Includes` directory:
-    - FXP.llb
     - Modules.lvlibp
     - NI ECAT Remote IO.llb
-1. Open `Scan Engine.lvproj`
+1. Open `Scan Engine.lvproj` in LabVIEW 32-bit
 1. Build all `Application (EXE)' build specifications:
     - Get HW Config
     - Check and Download Bitfile
     - Revert to Scan Mode
     - Import ESI File
     - Read Target ESI File
+1. Close LabVIEW 32-bit completely
+1. Open `Scan Engine.lvproj` in LabVIEW 64-bit
 1. Build the `Configuration Release` build specification
 
 The final file structure of the `Built` directory should be as follows (only two directory levels are shown):


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Update the `Manual Build Instructions` document
   - Describe how to use LabVIEW 2021+ to build 64-bit versions of the custom device
   - Update with new split target projects
- Add a new document explaining which files to copy between 32-bit and 64-bit LabVIEW installations for 2021+

### Why should this Pull Request be merged?

Building for VeriStand 2021 and 2023 versions is very difficult without knowing which bitness is required and how to work around missing 64-bit driver support. It's still very difficult, but at least it's now documented.

### What testing has been done?

Followed the steps with LabVIEW 2021 SP1 and tested the build with VeriStand 2021 R3.