### PR TITLE
Add x86 packaging and manifest.json

### DIFF
--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -58,16 +58,19 @@ steps:
           {
             Write-Host '##vso[task.setvariable variable=shortLvVersion]20'
             Write-Host '##vso[task.setvariable variable=nipkgx64suffix]'
+            Write-Host '##vso[task.setvariable variable=nipkgx86suffix]-x86'
           }
           Elseif ('${{ lvVersion }}' -eq '2021')
           {
             Write-Host '##vso[task.setvariable variable=shortLvVersion]21'
             Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
+            Write-Host '##vso[task.setvariable variable=nipkgx86suffix]'
           }
           Elseif ('${{ lvVersion }}' -eq '2023')
           {
             Write-Host '##vso[task.setvariable variable=shortLvVersion]23'
             Write-Host '##vso[task.setvariable variable=nipkgx64suffix]64'
+            Write-Host '##vso[task.setvariable variable=nipkgx86suffix]'
           }
           Else
           {
@@ -104,6 +107,7 @@ steps:
                 -replace "{display_version}", "$(releaseVersion)" `
                 -replace "{quarterly_display_version}", "$(quarterlyReleaseVersion)" `
                 -replace "{labview_short_version}", "$(shortLvVersion)" `
+                -replace "{pkg_x86_bitness_suffix}", "$(nipkgx86suffix)" `
                 -replace "{nipkgx64suffix}", "$(nipkgx64suffix)"
               Write-Output $contents
               Set-Content -Value $contents -Path 'nipkg\control\control'
@@ -144,6 +148,32 @@ steps:
                 -Destination $installerPath `
                 -Include *.nipkg `
                 -Recurse
+
+  - task: PowerShell@2
+    displayName: Create manifest file
+    inputs:
+      targetType: 'inline'
+      script: |
+        $installerPath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer'
+        If ( ("$(sourceBranch)" -match "release") -and (Test-Path $installerPath) )
+        {
+          Write-Output "Adding manifest file to release branch installer directory"
+          $jsonFilePath = Join-Path $installerPath "manifest.json"
+          $scmObject = [PSCustomObject]@{
+            GIT_BRANCH = "$(sourceBranch)"
+            GIT_COMMIT = "$(Build.SourceVersion)"
+            GIT_URL = "$(Build.Repository.Uri)"
+          }
+          $outputObject = [PSCustomObject]@{
+            scm = $scmObject
+          }
+          $jsonString = $outputObject | ConvertTo-Json
+          Set-Content -Path $jsonFilePath -Value $jsonString
+        }
+        Else
+        {
+          Write-Output "No release branch packages built; skipping manifest file"
+        }
 
   - task: PowerShell@2
     displayName: Rename nipkg files to match branch type

--- a/custom-packaging.yml
+++ b/custom-packaging.yml
@@ -149,31 +149,31 @@ steps:
                 -Include *.nipkg `
                 -Recurse
 
-  - task: PowerShell@2
-    displayName: Create manifest file
-    inputs:
-      targetType: 'inline'
-      script: |
-        $installerPath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer'
-        If ( ("$(sourceBranch)" -match "release") -and (Test-Path $installerPath) )
-        {
-          Write-Output "Adding manifest file to release branch installer directory"
-          $jsonFilePath = Join-Path $installerPath "manifest.json"
-          $scmObject = [PSCustomObject]@{
-            GIT_BRANCH = "$(sourceBranch)"
-            GIT_COMMIT = "$(Build.SourceVersion)"
-            GIT_URL = "$(Build.Repository.Uri)"
+    - task: PowerShell@2
+      displayName: Create manifest file
+      inputs:
+        targetType: 'inline'
+        script: |
+          $installerPath = '$(archivePath)\$(Build.BuildNumber)\$(lvVersion)\installer'
+          If ( ("$(sourceBranch)" -match "release") -and (Test-Path $installerPath) )
+          {
+            Write-Output "Adding manifest file to release branch installer directory"
+            $jsonFilePath = Join-Path $installerPath "manifest.json"
+            $scmObject = [PSCustomObject]@{
+              GIT_BRANCH = "$(sourceBranch)"
+              GIT_COMMIT = "$(Build.SourceVersion)"
+              GIT_URL = "$(Build.Repository.Uri)"
+            }
+            $outputObject = [PSCustomObject]@{
+              scm = $scmObject
+            }
+            $jsonString = $outputObject | ConvertTo-Json
+            Set-Content -Path $jsonFilePath -Value $jsonString
           }
-          $outputObject = [PSCustomObject]@{
-            scm = $scmObject
+          Else
+          {
+            Write-Output "No release branch packages built; skipping manifest file"
           }
-          $jsonString = $outputObject | ConvertTo-Json
-          Set-Content -Path $jsonFilePath -Value $jsonString
-        }
-        Else
-        {
-          Write-Output "No release branch packages built; skipping manifest file"
-        }
 
   - task: PowerShell@2
     displayName: Rename nipkg files to match branch type


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds behavior outlined in 
https://github.com/ni/niveristand-custom-device-build-tools/pull/158
and
https://github.com/ni/niveristand-custom-device-build-tools/pull/157

### Why should this Pull Request be merged?

Scan engine has custom packaging needs and so it currently has a separate packaging that requires these edits to be made to it specifically.

### What testing has been done?

Output of PR build.
