### PR TITLE
Add silence dependency failures optional parameter

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,8 @@ stages:
           file: '$target\NI ECAT Remote IO.llb'
           destination: 'Includes'
 
+      silenceDependencyFailures: true
+
       codegenVis:
         - 'Custom Device Source\Build VIs\Delete Scripting API.vi'
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a parameter to silently skip when dependencies fail.

### Why should this Pull Request be merged?

SEECD includes dependencies in some bitnesses but not others, and this is the easiest way to accommodate it's unique needs.

### What testing has been done?

SEECD pipeline can't be run before submission since it requires a top level parameter that doesn't existin build-tools main.