### PR TITLE
Bump release version to 23.5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,7 +143,7 @@ stages:
             - version: '2023'
               bitness: '32bit'
 
-      releaseVersion: '23.3.0'
+      releaseVersion: '23.5.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\scan_engine_custom_device'
       packages:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update release version in pipeline file to 23.5

### Why should this Pull Request be merged?

Build packages with the 23.5 version to be used in the next release.

### What testing has been done?

None
