### PR TITLE
Swap bitness build orders to get 64-bit error paths

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,13 +28,13 @@ stages:
         - version: '2020'
           bitness: '32bit'
         - version: '2021'
-          bitness: '32bit'
+          bitness: '64bit'
         - version: '2021'
-          bitness: '64bit'
-        - version: '2023'
           bitness: '32bit'
         - version: '2023'
           bitness: '64bit'
+        - version: '2023'
+          bitness: '32bit'
 
       dependencies:
         - source: '\\nirvana\Measurements\VeriStandAddons\scan_engine_fxp'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Swap build order of 32-bit and 64-bit versions to ensure packaging variables for 2021+ are set to 64-bit

### Why should this Pull Request be merged?

Fix AzDO Bug 2403000
Currently, the errors file is installed to 32-bit paths due to the 32-bit packaging step happening before the 64-bit.

### What testing has been done?

Dev branch build to validate the package output has the correct path:
![image](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/assets/31290917/055bc183-7f2d-4ace-8d16-9df36223ff9a)

