### PR TITLE
Revert "Dropped 32 bit lv support for testing (#274)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,10 +33,16 @@ stages:
       lvVersionsToBuild:
         - version: '2023'
           bitness: '64bit'
+        - version: '2023'
+          bitness: '32bit'
         - version: '2024'
           bitness: '64bit'
+        - version: '2024'
+          bitness: '32bit'
         - version: '2025'
           bitness: '64bit'
+        - version: '2025'
+          bitness: '32bit'
 
       dependencies:
         - source: '\\nirvana\Measurements\VeriStandAddons\scan_engine_fxp'
@@ -59,6 +65,13 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'Configuration Release'
+          exclusions:
+            - version: '2023'
+              bitness: '32bit'
+            - version: '2024'
+              bitness: '32bit'
+            - version: '2025'
+              bitness: '32bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
           buildOperation: 'ExecuteBuildSpec'
@@ -136,11 +149,25 @@ stages:
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'Scripting API'
+          exclusions:
+            - version: '2023'
+              bitness: '32bit'
+            - version: '2024'
+              bitness: '32bit'
+            - version: '2025'
+              bitness: '32bit'
 
         - projectLocation: 'Scripting Examples\Scan Engine Scripting Examples.lvproj'
           buildOperation: 'ExecuteBuildSpec'
           target: 'My Computer'
           buildSpec: 'Examples'
+          exclusions:
+            - version: '2023'
+              bitness: '32bit'
+            - version: '2024'
+              bitness: '32bit'
+            - version: '2025'
+              bitness: '32bit'
 
       releaseVersion: '25.0.0'
       buildOutputLocation: 'Built'


### PR DESCRIPTION
This reverts commit fbee82653b837139501c95f505f54a9683b97e58.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Reverted the changes related to dropping 32-bit LabVIEW support, as building the Scan Engine Custom Device requires LabVIEW 32-bit

### Why should this Pull Request be merged?

Required for future release.

### What testing has been done?

PR Build.
