### PR TITLE
Added LV-2026 and removed LV-2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ LabVIEW 2020
 
 ### Running the custom device
 
-- [VeriStand 2023 or later](https://www.ni.com/en-us/support/downloads/software-products/download.veristand.html)
+- [VeriStand 2024 or later](https://www.ni.com/en-us/support/downloads/software-products/download.veristand.html)
 - [NI CompactRIO](https://www.ni.com/en-us/support/downloads/drivers/download.ni-compactrio.html)
 - [NI-Industrial Communications for EtherCAT](https://www.ni.com/en-us/support/downloads/drivers/download.ni-industrial-communications-for-ethercat.html)
 
@@ -36,7 +36,7 @@ LabVIEW 2020
 
 The additional software listed below is required to develop or build this custom device from source. Manual build instructions are located [here](docs/Manual%20Build%20Instructions.md).
 
-- [LabVIEW 2023 or later](https://www.ni.com/en-us/support/downloads/software-products/download.labview.html)
+- [LabVIEW 2024 or later](https://www.ni.com/en-us/support/downloads/software-products/download.labview.html)
 - [LabVIEW FPGA Module](https://www.ni.com/en-us/support/downloads/software-products/download.labview-fpga-module.html)
 - [LabVIEW Real-Time Module](https://www.ni.com/en-us/support/downloads/software-products/download.labview-real-time-module.html)
 - [VeriStand Custom Device Development Tools](https://github.com/ni/niveristand-custom-device-development-tools)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,10 +31,6 @@ stages:
     parameters:
 
       lvVersionsToBuild:
-        - version: '2023'
-          bitness: '64bit'
-        - version: '2023'
-          bitness: '32bit'
         - version: '2024'
           bitness: '64bit'
         - version: '2024'
@@ -42,6 +38,10 @@ stages:
         - version: '2025'
           bitness: '64bit'
         - version: '2025'
+          bitness: '32bit'
+        - version: '2026'
+          bitness: '64bit'
+        - version: '2026'
           bitness: '32bit'
 
       dependencies:
@@ -66,11 +66,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Configuration Release'
           exclusions:
-            - version: '2023'
-              bitness: '32bit'
             - version: '2024'
               bitness: '32bit'
             - version: '2025'
+              bitness: '32bit'
+            - version: '2026'
               bitness: '32bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
@@ -78,11 +78,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Revert to Scan Mode'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
@@ -90,11 +90,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Get HW Config'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
@@ -102,11 +102,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Check and Download Bitfile'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
@@ -114,11 +114,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Import ESI File'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
@@ -126,11 +126,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Read Target ESI Files'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine Linux x64.lvproj'
@@ -138,11 +138,11 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Engine Release'
           exclusions:
-            - version: '2023'
-              bitness: '64bit'
             - version: '2024'
               bitness: '64bit'
             - version: '2025'
+              bitness: '64bit'
+            - version: '2026'
               bitness: '64bit'
 
         - projectLocation: 'Custom Device Source\Scan Engine.lvproj'
@@ -150,11 +150,11 @@ stages:
           target: 'My Computer'
           buildSpec: 'Scripting API'
           exclusions:
-            - version: '2023'
-              bitness: '32bit'
             - version: '2024'
               bitness: '32bit'
             - version: '2025'
+              bitness: '32bit'
+            - version: '2026'
               bitness: '32bit'
 
         - projectLocation: 'Scripting Examples\Scan Engine Scripting Examples.lvproj'
@@ -162,14 +162,14 @@ stages:
           target: 'My Computer'
           buildSpec: 'Examples'
           exclusions:
-            - version: '2023'
-              bitness: '32bit'
             - version: '2024'
               bitness: '32bit'
             - version: '2025'
               bitness: '32bit'
+            - version: '2026'
+              bitness: '32bit'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '26.0.0'
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\scan_engine_custom_device'
       packages:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump version to 26.0.0, drop 2023 build

### Why should this Pull Request be merged?

Required for release

### What testing has been done?

PR build
