### PR TITLE
Add gateway.ini configuration file for niveristand-scan-engine-ethercat-custom-device

### DIFF
--- a/Custom Device Source/Tests/EtherCAT System Tests/gateway.ini
+++ b/Custom Device Source/Tests/EtherCAT System Tests/gateway.ini
@@ -1,0 +1,5 @@
+[Gateway Settings]
+Enable Remote Gateway = False
+GatewayIP = localhost
+Username = admin
+System Path = ""

--- a/Custom Device Source/Tests/Specialty Digital System Tests/gateway.ini
+++ b/Custom Device Source/Tests/Specialty Digital System Tests/gateway.ini
@@ -1,0 +1,5 @@
+[Gateway Settings]
+Enable Remote Gateway = False
+GatewayIP = localhost
+Username = admin
+System Path = ""

--- a/Custom Device Source/Tests/cRIO System Tests/gateway.ini
+++ b/Custom Device Source/Tests/cRIO System Tests/gateway.ini
@@ -1,0 +1,5 @@
+[Gateway Settings]
+Enable Remote Gateway = False
+GatewayIP = localhost
+Username = admin
+System Path = ""

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,10 @@ trigger:
       - main
       - release/*
 
+variables:
+  - name: ConvertNetCore
+    value: false
+
 resources:
   repositories:
     - repository: niveristand-custom-device-build-tools
@@ -173,7 +177,6 @@ stages:
       buildOutputLocation: 'Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\scan_engine_custom_device'
       repoName: 'niveristand-scan-engine-ethercat-custom-device'
-      createNetCoreRepo: true
       packages:
         - controlFileName: 'control'
           payloadMaps:


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-scan-engine-ethercat-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

creating a gateway.ini file for niveristand-scan-engine-ethercat-custom-device. The file contains gateway configuration like Enable Remote Gateway ,GatewayIP,Username ,System Path .

### Why should this Pull Request be merged?

It enables tests to use gateway configurations dynamically.

### What testing has been done?

None
